### PR TITLE
Adds varint to hexify

### DIFF
--- a/multistream_select/utils.py
+++ b/multistream_select/utils.py
@@ -1,6 +1,6 @@
 # returns hex value of a string with its length encoded
 # in the beginning
-
+from pyint import encode
 
 def hexify(payload):
     """
@@ -15,6 +15,7 @@ def hexify(payload):
     payload_length = len(delimited_payload)
     payload_list = [ord(ch) for ch in delimited_payload]
     payload_hex = [format(val, 'x') for val in payload_list]
-    payload_hex = ''.join(payload_hex)
-    len_delimited_payload = hex(payload_length) + payload_hex
+    payload_hex_padded = [val if len(val) > 1 else '0'+val for val in payload_hex]
+    payload_hex_padded = ''.join(payload_hex_padded)
+    len_delimited_payload = "0x" + encode(payload_length, return_type="hex")[0] + payload_hex_padded
     return len_delimited_payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ six==1.11.0
 typed-ast==1.1.0
 wrapt==1.10.11
 yapf==0.24.0
+pyint==1.1.0


### PR DESCRIPTION
Since the first <x> number of bytes are the varint representation of the
length of the payload, we need a way other than hex(). Adding varint to
fix this